### PR TITLE
feat: adicionar CRUD de inspetores e inspeções

### DIFF
--- a/src/main/java/com/crm/springSecurity/controller/InspectionController.java
+++ b/src/main/java/com/crm/springSecurity/controller/InspectionController.java
@@ -12,8 +12,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -46,6 +50,32 @@ public class InspectionController {
     @GetMapping
     public List<Inspection> listarInspections(@RequestParam(value = "inspetorId", required = false) Long inspetorId) {
         return inspectionService.listar(inspetorId);
+    }
+
+
+    @Operation(summary = "Buscar inspeção por ID")
+    @GetMapping("/{id}")
+    public Inspection buscarPorId(@PathVariable Long id) {
+        return inspectionService.buscarPorId(id);
+    }
+
+    @Operation(summary = "Criar inspeção")
+    @PostMapping
+    public ResponseEntity<Inspection> criar(@RequestBody Inspection inspection) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(inspectionService.criar(inspection));
+    }
+
+    @Operation(summary = "Atualizar inspeção")
+    @PutMapping("/{id}")
+    public Inspection atualizar(@PathVariable Long id, @RequestBody Inspection inspection) {
+        return inspectionService.atualizar(id, inspection);
+    }
+
+    @Operation(summary = "Excluir inspeção")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> excluir(@PathVariable Long id) {
+        inspectionService.excluir(id);
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(

--- a/src/main/java/com/crm/springSecurity/controller/InspectorController.java
+++ b/src/main/java/com/crm/springSecurity/controller/InspectorController.java
@@ -1,0 +1,61 @@
+package com.crm.springSecurity.controller;
+
+import com.crm.springSecurity.model.Inspector;
+import com.crm.springSecurity.service.InspectorService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Inspetores", description = "APIs para cadastro de inspetores")
+@RestController
+@RequestMapping("/api/inspectors")
+public class InspectorController {
+
+    private final InspectorService inspectorService;
+
+    public InspectorController(InspectorService inspectorService) {
+        this.inspectorService = inspectorService;
+    }
+
+    @Operation(summary = "Listar inspetores")
+    @GetMapping
+    public List<Inspector> listar() {
+        return inspectorService.listar();
+    }
+
+    @Operation(summary = "Buscar inspetor por ID")
+    @GetMapping("/{id}")
+    public Inspector buscarPorId(@PathVariable Long id) {
+        return inspectorService.buscarPorId(id);
+    }
+
+    @Operation(summary = "Criar inspetor")
+    @PostMapping
+    public ResponseEntity<Inspector> criar(@RequestBody Inspector inspector) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(inspectorService.criar(inspector));
+    }
+
+    @Operation(summary = "Atualizar inspetor")
+    @PutMapping("/{id}")
+    public Inspector atualizar(@PathVariable Long id, @RequestBody Inspector inspector) {
+        return inspectorService.atualizar(id, inspector);
+    }
+
+    @Operation(summary = "Excluir inspetor")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> excluir(@PathVariable Long id) {
+        inspectorService.excluir(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/crm/springSecurity/model/Inspector.java
+++ b/src/main/java/com/crm/springSecurity/model/Inspector.java
@@ -1,0 +1,64 @@
+package com.crm.springSecurity.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "inspectors")
+public class Inspector {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String nome;
+
+    private String email;
+    private String telefone;
+    private Boolean ativo = true;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getTelefone() {
+        return telefone;
+    }
+
+    public void setTelefone(String telefone) {
+        this.telefone = telefone;
+    }
+
+    public Boolean getAtivo() {
+        return ativo;
+    }
+
+    public void setAtivo(Boolean ativo) {
+        this.ativo = ativo;
+    }
+}

--- a/src/main/java/com/crm/springSecurity/repository/InspectorRepository.java
+++ b/src/main/java/com/crm/springSecurity/repository/InspectorRepository.java
@@ -1,0 +1,7 @@
+package com.crm.springSecurity.repository;
+
+import com.crm.springSecurity.model.Inspector;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InspectorRepository extends JpaRepository<Inspector, Long> {
+}

--- a/src/main/java/com/crm/springSecurity/service/InspectionService.java
+++ b/src/main/java/com/crm/springSecurity/service/InspectionService.java
@@ -2,7 +2,9 @@ package com.crm.springSecurity.service;
 
 import com.crm.springSecurity.model.Inspection;
 import com.crm.springSecurity.repository.InspectionRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -20,5 +22,26 @@ public class InspectionService {
             return inspectionRepository.findAll();
         }
         return inspectionRepository.findByInspetorId(inspetorId);
+    }
+
+    public Inspection buscarPorId(Long id) {
+        return inspectionRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Inspeção não encontrada"));
+    }
+
+    public Inspection criar(Inspection inspection) {
+        inspection.setId(null);
+        return inspectionRepository.save(inspection);
+    }
+
+    public Inspection atualizar(Long id, Inspection inspection) {
+        Inspection existente = buscarPorId(id);
+        inspection.setId(existente.getId());
+        return inspectionRepository.save(inspection);
+    }
+
+    public void excluir(Long id) {
+        Inspection existente = buscarPorId(id);
+        inspectionRepository.delete(existente);
     }
 }

--- a/src/main/java/com/crm/springSecurity/service/InspectorService.java
+++ b/src/main/java/com/crm/springSecurity/service/InspectorService.java
@@ -1,0 +1,47 @@
+package com.crm.springSecurity.service;
+
+import com.crm.springSecurity.model.Inspector;
+import com.crm.springSecurity.repository.InspectorRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@Service
+public class InspectorService {
+
+    private final InspectorRepository inspectorRepository;
+
+    public InspectorService(InspectorRepository inspectorRepository) {
+        this.inspectorRepository = inspectorRepository;
+    }
+
+    public List<Inspector> listar() {
+        return inspectorRepository.findAll();
+    }
+
+    public Inspector buscarPorId(Long id) {
+        return inspectorRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Inspetor não encontrado"));
+    }
+
+    public Inspector criar(Inspector inspector) {
+        inspector.setId(null);
+        return inspectorRepository.save(inspector);
+    }
+
+    public Inspector atualizar(Long id, Inspector inspector) {
+        Inspector existente = buscarPorId(id);
+        existente.setNome(inspector.getNome());
+        existente.setEmail(inspector.getEmail());
+        existente.setTelefone(inspector.getTelefone());
+        existente.setAtivo(inspector.getAtivo());
+        return inspectorRepository.save(existente);
+    }
+
+    public void excluir(Long id) {
+        Inspector existente = buscarPorId(id);
+        inspectorRepository.delete(existente);
+    }
+}

--- a/src/test/java/com/crm/springSecurity/service/InspectionServiceTest.java
+++ b/src/test/java/com/crm/springSecurity/service/InspectionServiceTest.java
@@ -3,10 +3,12 @@ package com.crm.springSecurity.service;
 import com.crm.springSecurity.model.Inspection;
 import com.crm.springSecurity.repository.InspectionRepository;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class InspectionServiceTest {
@@ -37,5 +39,51 @@ class InspectionServiceTest {
         assertEquals(1, resultado.size());
         verify(repository).findByInspetorId(42L);
         verify(repository, never()).findAll();
+    }
+
+    @Test
+    void deveCriarInspecaoComIdNulo() {
+        InspectionRepository repository = mock(InspectionRepository.class);
+        InspectionService service = new InspectionService(repository);
+
+        Inspection inspection = new Inspection();
+        inspection.setId(12L);
+
+        when(repository.save(any(Inspection.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Inspection criada = service.criar(inspection);
+
+        assertNull(criada.getId());
+        verify(repository).save(inspection);
+    }
+
+    @Test
+    void deveAtualizarInspecaoExistente() {
+        InspectionRepository repository = mock(InspectionRepository.class);
+        InspectionService service = new InspectionService(repository);
+
+        Inspection existente = new Inspection();
+        existente.setId(5L);
+
+        Inspection payload = new Inspection();
+        payload.setStatus("DONE");
+
+        when(repository.findById(5L)).thenReturn(Optional.of(existente));
+        when(repository.save(any(Inspection.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Inspection atualizada = service.atualizar(5L, payload);
+
+        assertEquals(5L, atualizada.getId());
+        assertEquals("DONE", atualizada.getStatus());
+    }
+
+    @Test
+    void deveLancarNotFoundAoBuscarInspecaoInexistente() {
+        InspectionRepository repository = mock(InspectionRepository.class);
+        InspectionService service = new InspectionService(repository);
+
+        when(repository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThrows(ResponseStatusException.class, () -> service.buscarPorId(999L));
     }
 }

--- a/src/test/java/com/crm/springSecurity/service/InspectorServiceTest.java
+++ b/src/test/java/com/crm/springSecurity/service/InspectorServiceTest.java
@@ -1,0 +1,42 @@
+package com.crm.springSecurity.service;
+
+import com.crm.springSecurity.model.Inspector;
+import com.crm.springSecurity.repository.InspectorRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class InspectorServiceTest {
+
+    @Test
+    void deveCriarInspectorZerandoId() {
+        InspectorRepository repository = mock(InspectorRepository.class);
+        InspectorService service = new InspectorService(repository);
+
+        Inspector inspector = new Inspector();
+        inspector.setId(99L);
+        inspector.setNome("Carlos");
+
+        when(repository.save(any(Inspector.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Inspector salvo = service.criar(inspector);
+
+        assertNull(salvo.getId());
+        assertEquals("Carlos", salvo.getNome());
+        verify(repository).save(inspector);
+    }
+
+    @Test
+    void deveLancarNotFoundQuandoInspectorNaoExiste() {
+        InspectorRepository repository = mock(InspectorRepository.class);
+        InspectorService service = new InspectorService(repository);
+
+        when(repository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThrows(ResponseStatusException.class, () -> service.buscarPorId(1L));
+    }
+}


### PR DESCRIPTION
### Motivation
- Disponibilizar APIs REST para que o front possa gerenciar inspetores e inspeções (CRUD completo). 
- Fornecer modelo JPA e serviços com comportamento consistente (criar com id nulo, 404 quando não encontrado). 
- Manter o endpoint de importação de planilhas existente para inspeções. 

### Description
- Adicionada a entidade `Inspector` (`src/main/java/.../model/Inspector.java`) e o repositório `InspectorRepository` para persistência. 
- Implementado `InspectorService` com operações `listar`, `buscarPorId`, `criar`, `atualizar` e `excluir`, e `InspectorController` expondo `/api/inspectors` com `GET`, `GET/{id}`, `POST`, `PUT/{id}` e `DELETE/{id}`. 
- Expandido `InspectionService` com `buscarPorId`, `criar`, `atualizar` e `excluir`, e atualizado `InspectionController` para expor os endpoints CRUD em `/api/inspections` preservando o `POST /api/inspections/import`. 
- Criados/atualizados testes unitários em `src/test/java/.../InspectorServiceTest.java` e `src/test/java/.../InspectionServiceTest.java` cobrindo criação, atualização e caminhos de não-encontrado. 

### Testing
- Foram adicionados testes unitários `InspectorServiceTest` e `InspectionServiceTest` no diretório `src/test/java`. 
- Tentativa de execução com `./mvnw -q -Dtest=InspectionServiceTest,InspectorServiceTest test` falhou no ambiente por permissão/instalação do wrapper. 
- Tentativa com `mvn -q -Dtest=InspectionServiceTest,InspectorServiceTest test` falhou por erro de resolução de dependências (acesso ao Maven Central retornou HTTP 403), portanto os testes não foram executados com sucesso neste ambiente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d3d1caedc8322b6c15ddadf442ec8)