### PR TITLE
Fix inspector table mapping and add foto_inspections CRUD

### DIFF
--- a/src/main/java/com/crm/springSecurity/controller/FotoInspectionController.java
+++ b/src/main/java/com/crm/springSecurity/controller/FotoInspectionController.java
@@ -1,0 +1,54 @@
+package com.crm.springSecurity.controller;
+
+import com.crm.springSecurity.model.FotoInspection;
+import com.crm.springSecurity.service.FotoInspectionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Fotos de inspeção", description = "APIs para CRUD de fotos ligadas às inspeções")
+@RestController
+@RequestMapping("/api/foto-inspections")
+public class FotoInspectionController {
+
+    private final FotoInspectionService fotoInspectionService;
+
+    public FotoInspectionController(FotoInspectionService fotoInspectionService) {
+        this.fotoInspectionService = fotoInspectionService;
+    }
+
+    @Operation(summary = "Listar fotos de inspeção")
+    @GetMapping
+    public List<FotoInspection> listar(@RequestParam(value = "inspectionId", required = false) Long inspectionId) {
+        return fotoInspectionService.listar(inspectionId);
+    }
+
+    @Operation(summary = "Buscar foto de inspeção por ID")
+    @GetMapping("/{id}")
+    public FotoInspection buscarPorId(@PathVariable Long id) {
+        return fotoInspectionService.buscarPorId(id);
+    }
+
+    @Operation(summary = "Criar foto de inspeção")
+    @PostMapping
+    public ResponseEntity<FotoInspection> criar(@RequestBody FotoInspection fotoInspection) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(fotoInspectionService.criar(fotoInspection));
+    }
+
+    @Operation(summary = "Atualizar foto de inspeção")
+    @PutMapping("/{id}")
+    public FotoInspection atualizar(@PathVariable Long id, @RequestBody FotoInspection fotoInspection) {
+        return fotoInspectionService.atualizar(id, fotoInspection);
+    }
+
+    @Operation(summary = "Excluir foto de inspeção")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> excluir(@PathVariable Long id) {
+        fotoInspectionService.excluir(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/crm/springSecurity/model/FotoInspection.java
+++ b/src/main/java/com/crm/springSecurity/model/FotoInspection.java
@@ -1,0 +1,52 @@
+package com.crm.springSecurity.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "foto_inspections")
+public class FotoInspection {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "inspection_id", nullable = false)
+    private Long inspectionId;
+
+    private String descricao;
+
+    @Column(nullable = false)
+    private byte[] foto;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getInspectionId() {
+        return inspectionId;
+    }
+
+    public void setInspectionId(Long inspectionId) {
+        this.inspectionId = inspectionId;
+    }
+
+    public String getDescricao() {
+        return descricao;
+    }
+
+    public void setDescricao(String descricao) {
+        this.descricao = descricao;
+    }
+
+    public byte[] getFoto() {
+        return foto;
+    }
+
+    public void setFoto(byte[] foto) {
+        this.foto = foto;
+    }
+}

--- a/src/main/java/com/crm/springSecurity/model/Inspector.java
+++ b/src/main/java/com/crm/springSecurity/model/Inspector.java
@@ -8,7 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 @Entity
-@Table(name = "inspectors")
+@Table(name = "inspetor")
 public class Inspector {
 
     @Id
@@ -17,10 +17,6 @@ public class Inspector {
 
     @Column(nullable = false)
     private String nome;
-
-    private String email;
-    private String telefone;
-    private Boolean ativo = true;
 
     public Long getId() {
         return id;
@@ -36,29 +32,5 @@ public class Inspector {
 
     public void setNome(String nome) {
         this.nome = nome;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getTelefone() {
-        return telefone;
-    }
-
-    public void setTelefone(String telefone) {
-        this.telefone = telefone;
-    }
-
-    public Boolean getAtivo() {
-        return ativo;
-    }
-
-    public void setAtivo(Boolean ativo) {
-        this.ativo = ativo;
     }
 }

--- a/src/main/java/com/crm/springSecurity/repository/FotoInspectionRepository.java
+++ b/src/main/java/com/crm/springSecurity/repository/FotoInspectionRepository.java
@@ -1,0 +1,10 @@
+package com.crm.springSecurity.repository;
+
+import com.crm.springSecurity.model.FotoInspection;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FotoInspectionRepository extends JpaRepository<FotoInspection, Long> {
+    List<FotoInspection> findByInspectionId(Long inspectionId);
+}

--- a/src/main/java/com/crm/springSecurity/service/FotoInspectionService.java
+++ b/src/main/java/com/crm/springSecurity/service/FotoInspectionService.java
@@ -1,0 +1,59 @@
+package com.crm.springSecurity.service;
+
+import com.crm.springSecurity.model.FotoInspection;
+import com.crm.springSecurity.repository.FotoInspectionRepository;
+import com.crm.springSecurity.repository.InspectionRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@Service
+public class FotoInspectionService {
+
+    private final FotoInspectionRepository fotoInspectionRepository;
+    private final InspectionRepository inspectionRepository;
+
+    public FotoInspectionService(FotoInspectionRepository fotoInspectionRepository,
+                                 InspectionRepository inspectionRepository) {
+        this.fotoInspectionRepository = fotoInspectionRepository;
+        this.inspectionRepository = inspectionRepository;
+    }
+
+    public List<FotoInspection> listar(Long inspectionId) {
+        if (inspectionId == null) {
+            return fotoInspectionRepository.findAll();
+        }
+        return fotoInspectionRepository.findByInspectionId(inspectionId);
+    }
+
+    public FotoInspection buscarPorId(Long id) {
+        return fotoInspectionRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Foto da inspeção não encontrada"));
+    }
+
+    public FotoInspection criar(FotoInspection fotoInspection) {
+        fotoInspection.setId(null);
+        validarInspectionId(fotoInspection.getInspectionId());
+        return fotoInspectionRepository.save(fotoInspection);
+    }
+
+    public FotoInspection atualizar(Long id, FotoInspection fotoInspection) {
+        FotoInspection existente = buscarPorId(id);
+        validarInspectionId(fotoInspection.getInspectionId());
+        fotoInspection.setId(existente.getId());
+        return fotoInspectionRepository.save(fotoInspection);
+    }
+
+    public void excluir(Long id) {
+        FotoInspection existente = buscarPorId(id);
+        fotoInspectionRepository.delete(existente);
+    }
+
+    private void validarInspectionId(Long inspectionId) {
+        if (inspectionId == null || !inspectionRepository.existsById(inspectionId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "inspection_id inválido");
+        }
+    }
+}

--- a/src/main/java/com/crm/springSecurity/service/InspectorService.java
+++ b/src/main/java/com/crm/springSecurity/service/InspectorService.java
@@ -34,9 +34,6 @@ public class InspectorService {
     public Inspector atualizar(Long id, Inspector inspector) {
         Inspector existente = buscarPorId(id);
         existente.setNome(inspector.getNome());
-        existente.setEmail(inspector.getEmail());
-        existente.setTelefone(inspector.getTelefone());
-        existente.setAtivo(inspector.getAtivo());
         return inspectorRepository.save(existente);
     }
 

--- a/src/test/java/com/crm/springSecurity/service/FotoInspectionServiceTest.java
+++ b/src/test/java/com/crm/springSecurity/service/FotoInspectionServiceTest.java
@@ -1,0 +1,66 @@
+package com.crm.springSecurity.service;
+
+import com.crm.springSecurity.model.FotoInspection;
+import com.crm.springSecurity.repository.FotoInspectionRepository;
+import com.crm.springSecurity.repository.InspectionRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class FotoInspectionServiceTest {
+
+    @Test
+    void deveListarPorInspectionIdQuandoFiltroInformado() {
+        FotoInspectionRepository fotoRepository = mock(FotoInspectionRepository.class);
+        InspectionRepository inspectionRepository = mock(InspectionRepository.class);
+        FotoInspectionService service = new FotoInspectionService(fotoRepository, inspectionRepository);
+
+        when(fotoRepository.findByInspectionId(10L)).thenReturn(List.of(new FotoInspection()));
+
+        List<FotoInspection> resultado = service.listar(10L);
+
+        assertEquals(1, resultado.size());
+        verify(fotoRepository).findByInspectionId(10L);
+        verify(fotoRepository, never()).findAll();
+    }
+
+    @Test
+    void deveCriarFotoQuandoInspectionIdValido() {
+        FotoInspectionRepository fotoRepository = mock(FotoInspectionRepository.class);
+        InspectionRepository inspectionRepository = mock(InspectionRepository.class);
+        FotoInspectionService service = new FotoInspectionService(fotoRepository, inspectionRepository);
+
+        FotoInspection foto = new FotoInspection();
+        foto.setId(5L);
+        foto.setInspectionId(1L);
+        foto.setFoto(new byte[]{1, 2, 3});
+
+        when(inspectionRepository.existsById(1L)).thenReturn(true);
+        when(fotoRepository.save(any(FotoInspection.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        FotoInspection salvo = service.criar(foto);
+
+        assertNull(salvo.getId());
+        verify(fotoRepository).save(foto);
+    }
+
+    @Test
+    void deveFalharQuandoInspectionIdInvalido() {
+        FotoInspectionRepository fotoRepository = mock(FotoInspectionRepository.class);
+        InspectionRepository inspectionRepository = mock(InspectionRepository.class);
+        FotoInspectionService service = new FotoInspectionService(fotoRepository, inspectionRepository);
+
+        FotoInspection foto = new FotoInspection();
+        foto.setInspectionId(999L);
+        foto.setFoto(new byte[]{1});
+
+        when(inspectionRepository.existsById(999L)).thenReturn(false);
+
+        assertThrows(ResponseStatusException.class, () -> service.criar(foto));
+        verify(fotoRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
### Motivation
- Ajustar o mapeamento das entidades para ficar consistente com o DDL PostgreSQL fornecido (tabela `inspetor`) e evitar erros de CRUD por colunas inexistentes. 
- Implementar suporte a fotos de inspeção porque o modelo `foto_inspections` existia no DDL mas não havia CRUD correspondente na API.

### Description
- Atualiza a entidade `Inspector` para usar `@Table(name = "inspetor")` e remove campos não previstos no DDL (`email`, `telefone`, `ativo`).
- Ajusta `InspectorService.atualizar` para alterar apenas o campo `nome` compatível com o schema.
- Adiciona entidade `FotoInspection` mapeando `foto_inspections` com `inspection_id`, `descricao` e `foto` (`byte[]`).
- Adiciona `FotoInspectionRepository` com método `findByInspectionId`, `FotoInspectionService` com validação de `inspection_id` e CRUD completo, e `FotoInspectionController` expondo endpoints REST em `/api/foto-inspections`.
- Inclui testes unitários `FotoInspectionServiceTest` cobrindo listagem com filtro, criação com FK válida e falha quando FK inválido.

### Testing
- Adicionei os testes unitários para `FotoInspectionService` em `src/test/.../FotoInspectionServiceTest.java`, mas não foram executados na CI aqui por limitação de ambiente.
- `./mvnw test` falhou por problema com o wrapper/permissão/download, e `mvn test -q` falhou por resolução de dependências contra Maven Central (erro `403 Forbidden`), portanto a suíte não pôde ser executada neste ambiente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d4ca23ab48322a2665e549a7da346)