### PR TITLE
Fix SecurityConfig package casing to com.crm.springSecurity.config

### DIFF
--- a/src/main/java/com/crm/springSecurity/config/SecurityConfig.java
+++ b/src/main/java/com/crm/springSecurity/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.crm.springsecurity.config;
+package com.crm.springSecurity.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;


### PR DESCRIPTION
### Motivation
- A package declaration used `com.crm.springsecurity.config` (lowercase `s`) while the rest of the codebase uses `com.crm.springSecurity.*`, which breaks package resolution on case-sensitive filesystems.

### Description
- Moved `SecurityConfig` to `src/main/java/com/crm/springSecurity/config/SecurityConfig.java` and updated its package declaration to `package com.crm.springSecurity.config;` so the file path and package namespace match the project's existing casing.

### Testing
- Attempted to run `./mvnw -q -DskipTests compile`, which failed because the Maven wrapper could not download Maven from `repo.maven.apache.org` in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcc20a8c14832296209ef091a3e0b3)