### PR TITLE
Rename package to com.crm.zipupload and clean up pom dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,12 +78,6 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<!-- Spring Security -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency>
-
 		<!-- JWT -->
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
@@ -102,21 +96,9 @@
 			<version>0.11.5</version>
 			<scope>runtime</scope>
 		</dependency>
-		<!-- No pom.xml -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<!-- Se quiser testar endpoints integrados com segurança: -->
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/crm/zipupload/SpringSecurityApplication.java
+++ b/src/main/java/com/crm/zipupload/SpringSecurityApplication.java
@@ -1,4 +1,4 @@
-package com.crm.springsecurity;
+package com.crm.zipupload;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/crm/zipupload/controller/InspectionUploadController.java
+++ b/src/main/java/com/crm/zipupload/controller/InspectionUploadController.java
@@ -1,4 +1,4 @@
-package com.crm.springsecurity.controller;
+package com.crm.zipupload.controller;
 
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.crm.springsecurity.dto.ZipUploadResultDto;
-import com.crm.springsecurity.service.ZipInspectionUploadService;
+import com.crm.zipupload.dto.ZipUploadResultDto;
+import com.crm.zipupload.service.ZipInspectionUploadService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/src/main/java/com/crm/zipupload/dto/ZipUploadResultDto.java
+++ b/src/main/java/com/crm/zipupload/dto/ZipUploadResultDto.java
@@ -1,4 +1,4 @@
-package com.crm.springsecurity.dto;
+package com.crm.zipupload.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/crm/zipupload/entity/Inspection.java
+++ b/src/main/java/com/crm/zipupload/entity/Inspection.java
@@ -1,4 +1,4 @@
-package com.crm.springsecurity.entity;
+package com.crm.zipupload.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/src/main/java/com/crm/zipupload/entity/InspectionPhoto.java
+++ b/src/main/java/com/crm/zipupload/entity/InspectionPhoto.java
@@ -1,4 +1,4 @@
-package com.crm.springsecurity.entity;
+package com.crm.zipupload.entity;
 
 import java.time.OffsetDateTime;
 

--- a/src/main/java/com/crm/zipupload/entity/Inspector.java
+++ b/src/main/java/com/crm/zipupload/entity/Inspector.java
@@ -1,4 +1,4 @@
-package com.crm.springsecurity.entity;
+package com.crm.zipupload.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/crm/zipupload/repository/InspectionPhotoRepository.java
+++ b/src/main/java/com/crm/zipupload/repository/InspectionPhotoRepository.java
@@ -1,8 +1,8 @@
-package com.crm.springsecurity.repository;
+package com.crm.zipupload.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.crm.springsecurity.entity.InspectionPhoto;
+import com.crm.zipupload.entity.InspectionPhoto;
 
 public interface InspectionPhotoRepository extends JpaRepository<InspectionPhoto, Long> {
 }

--- a/src/main/java/com/crm/zipupload/repository/InspectionRepository.java
+++ b/src/main/java/com/crm/zipupload/repository/InspectionRepository.java
@@ -1,10 +1,10 @@
-package com.crm.springsecurity.repository;
+package com.crm.zipupload.repository;
 
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.crm.springsecurity.entity.Inspection;
+import com.crm.zipupload.entity.Inspection;
 
 public interface InspectionRepository extends JpaRepository<Inspection, Long> {
 

--- a/src/main/java/com/crm/zipupload/repository/InspectorRepository.java
+++ b/src/main/java/com/crm/zipupload/repository/InspectorRepository.java
@@ -1,8 +1,8 @@
-package com.crm.springsecurity.repository;
+package com.crm.zipupload.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.crm.springsecurity.entity.Inspector;
+import com.crm.zipupload.entity.Inspector;
 
 public interface InspectorRepository extends JpaRepository<Inspector, Long> {
 }

--- a/src/main/java/com/crm/zipupload/service/ZipInspectionUploadService.java
+++ b/src/main/java/com/crm/zipupload/service/ZipInspectionUploadService.java
@@ -1,4 +1,4 @@
-package com.crm.springsecurity.service;
+package com.crm.zipupload.service;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -16,13 +16,13 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
-import com.crm.springsecurity.dto.ZipUploadResultDto;
-import com.crm.springsecurity.entity.Inspection;
-import com.crm.springsecurity.entity.InspectionPhoto;
-import com.crm.springsecurity.entity.Inspector;
-import com.crm.springsecurity.repository.InspectionPhotoRepository;
-import com.crm.springsecurity.repository.InspectionRepository;
-import com.crm.springsecurity.repository.InspectorRepository;
+import com.crm.zipupload.dto.ZipUploadResultDto;
+import com.crm.zipupload.entity.Inspection;
+import com.crm.zipupload.entity.InspectionPhoto;
+import com.crm.zipupload.entity.Inspector;
+import com.crm.zipupload.repository.InspectionPhotoRepository;
+import com.crm.zipupload.repository.InspectionRepository;
+import com.crm.zipupload.repository.InspectorRepository;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;

--- a/src/test/java/com/crm/zipupload/service/ZipInspectionUploadServiceTest.java
+++ b/src/test/java/com/crm/zipupload/service/ZipInspectionUploadServiceTest.java
@@ -1,4 +1,4 @@
-package com.crm.springsecurity.service;
+package com.crm.zipupload.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -19,13 +19,13 @@ import org.mockito.Mockito;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
-import com.crm.springsecurity.dto.ZipUploadResultDto;
-import com.crm.springsecurity.entity.Inspection;
-import com.crm.springsecurity.entity.InspectionPhoto;
-import com.crm.springsecurity.entity.Inspector;
-import com.crm.springsecurity.repository.InspectionPhotoRepository;
-import com.crm.springsecurity.repository.InspectionRepository;
-import com.crm.springsecurity.repository.InspectorRepository;
+import com.crm.zipupload.dto.ZipUploadResultDto;
+import com.crm.zipupload.entity.Inspection;
+import com.crm.zipupload.entity.InspectionPhoto;
+import com.crm.zipupload.entity.Inspector;
+import com.crm.zipupload.repository.InspectionPhotoRepository;
+import com.crm.zipupload.repository.InspectionRepository;
+import com.crm.zipupload.repository.InspectorRepository;
 
 class ZipInspectionUploadServiceTest {
 


### PR DESCRIPTION
### Motivation

- Move the ZIP inspection upload feature into a clearer package namespace focused on zip upload functionality instead of a generic security package name.
- Remove unused or duplicate dependencies from `pom.xml` to simplify the build and avoid redundant declarations.

### Description

- Renamed package `com.crm.springsecurity` to `com.crm.zipupload` across application code, DTOs, entities, repositories, services, controller, and tests, and updated all corresponding import statements and file paths.
- Renamed source files and test classes under `src/main/java` and `src/test/java` to match the new package structure (for example `SpringSecurityApplication` moved to `com.crm.zipupload` and `ZipInspectionUploadServiceTest` moved accordingly). 
- Cleaned up `pom.xml` by removing the `spring-boot-starter-security` dependency and eliminating a duplicated `spring-boot-starter-test`/`spring-security-test` declaration.

### Testing

- Ran the project unit tests with `mvn test`, which executed the service unit tests including `ZipInspectionUploadServiceTest`, and they completed successfully.
- Verified compilation of the codebase after package renames by building the project with `mvn -DskipTests=false package`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcc6e24f608322b0042bc91aed1581)